### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,11 +1,11 @@
-# Display git branch and dirty bit and current time on the right 
+# Display git branch and dirty bit and current time on the right
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _is_git_dirty
-  echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+  echo (command git status -s --ignore-submodules=dirty 2> /dev/null)
 end
 
 function fish_right_prompt
@@ -16,7 +16,7 @@ function fish_right_prompt
   set -l green (set_color 80ff00)
   set -l pink (set_color ff99ff)
   set -l dark_pink (set_color cc99ff)
-  
+
 
   # Show git branch and dirty state
   if [ (_git_branch_name) ]
@@ -28,7 +28,7 @@ function fish_right_prompt
 		echo -n -s $cyan '‹' $yellow $git_branch $cyan '›' $normal
     end
   end
-  
+
   echo -n -s $pink ' [' $dark_pink (date +%H:%M:%S) $pink '] '
 
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618